### PR TITLE
shouldnt hardcode region

### DIFF
--- a/bin/stardock-common
+++ b/bin/stardock-common
@@ -110,7 +110,8 @@ function wait_for_docker_container() {
 function docker_login() {
   if docker_remote_is_enabled ; then
     local whoami=$(whoami)
-    eval $(aws --region us-east-1 ecr get-login --no-include-email)
+    get_aws_region
+    eval $(aws --region ${STARDOCK_AWS_REGION} ecr get-login --no-include-email)
   fi
 }
 


### PR DESCRIPTION
Will cause authentication errors when storing using ECR in other regions. 

Command: `aws --region us-east-1 ecr get-login --no-include-email`
Error: `An error occurred (UnrecognizedClientException) when calling the GetAuthorizationToken operation: The security token included in the request is invalid`

After fix: `docker login -u AWS -p someLongKeyBlob`